### PR TITLE
Split up `lib` and `tests` in dist.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ember-build-utilities",
   "version": "0.0.0",
   "description": "Utilities for constructing ember-cli based pipelines",
-  "main": "dist/index.js",
+  "main": "dist/lib/index.js",
   "repository": "git@github.com:ember-cli/ember-build-utilities.git",
   "author": "Chad Hietala <chadhietala@gmail.com>",
   "license": "MIT",
@@ -16,7 +16,10 @@
     "!dist/tests"
   ],
   "scripts": {
-    "build": "babel {lib,tests} --out-dir dist",
+    "build": "yarn run build:clean && yarn run build:lib && yarn run build:test",
+    "build:clean": "rm -rf dist",
+    "build:lib": "babel lib --out-dir dist/lib",
+    "build:test": "babel tests --out-dir dist/tests",
     "prepublish": "yarn build",
     "test": "yarn build  && qunit dist/**/*-test.js"
   },

--- a/tests/addons/notify-included-test.js
+++ b/tests/addons/notify-included-test.js
@@ -1,4 +1,4 @@
-import { notifyAddonIncluded } from '../../';
+import { notifyAddonIncluded } from '../../lib';
 import { module, test } from 'qunitjs';
 
 module('Notify Included', {

--- a/tests/addons/should-include-test.js
+++ b/tests/addons/should-include-test.js
@@ -1,4 +1,4 @@
-import { shouldIncludeAddon } from '../../';
+import { shouldIncludeAddon } from '../../lib';
 import { module, test } from 'qunitjs';
 
 module('Should Include Addon');

--- a/tests/paths/resolve-local-test.js
+++ b/tests/paths/resolve-local-test.js
@@ -1,4 +1,4 @@
-import { resolveLocal } from '../../';
+import { resolveLocal } from '../../lib';
 import { module, test } from 'qunitjs';
 
 module('Resolve Local');


### PR DESCRIPTION
Previously, the `lib` and `test` output was intermixed in `dist`. This changes them to match the actual structure on disk (so there is now a `dist/lib` and `dist/test`).

It also fixes the `files` blacklist of `!dist/tests` (which previously was non-existent).

While working on this, I noticed that `dist` is not cleaned prior to a build, leading to bizarre issues when files are removed/moved in lib or test.  I added a `build:clean` script to handle clearing this up.