### PR TITLE
Extract `managerId` from template filename into template meta

### DIFF
--- a/lib/compilers/glimmer/index.js
+++ b/lib/compilers/glimmer/index.js
@@ -12,12 +12,27 @@ export default class GlimmerTemplatePrecompiler extends Filter {
   }
 
   processString(content, relativePath) {
-    let specifier = getTemplateSpecifier(this.rootName, relativePath);
-    return `export default ${this.precompile(content, { meta: { specifier, '<template-meta>': true } })};`;
+    let specifier = getTemplateSpecifier(this.rootName, removeManagerIdFromPath(relativePath));
+    let managerId = getManagerIdFromPath(relativePath);
+    let meta = { specifier, '<template-meta>': true };
+
+    if (managerId) {
+      meta.managerId = managerId;
+    }
+
+    return `export default ${this.precompile(content, { meta })};`;
   }
 
   precompile(content, options) {
     return precompile(content, options);
+  }
+
+  getDestFilePath(relativePath) {
+    let processedPath = super.getDestFilePath(relativePath);
+
+    if (!processedPath) return processedPath;
+
+    return removeManagerIdFromPath(processedPath);
   }
 }
 
@@ -41,4 +56,27 @@ export function getTemplateSpecifier(rootName, relativePath) {
   }
 
   return `template:/${rootName}/${pathParts.join('/')}`;
+}
+
+function getManagerIdFromPath(path) {
+  let parts = path.split('.');
+  let managerId = null;
+
+  if (parts.length > 2) {
+    let lastIndex = parts.length - 1;
+    managerId = parts.splice(lastIndex - 1, 1)[0];
+  }
+
+  return managerId;
+}
+
+function removeManagerIdFromPath(path) {
+  let parts = path.split('.');
+
+  if (parts.length > 2) {
+    let lastIndex = parts.length - 1;
+    parts.splice(lastIndex - 1, 1);
+  }
+
+  return parts.join('.');
 }

--- a/lib/compilers/glimmer/index.js
+++ b/lib/compilers/glimmer/index.js
@@ -14,7 +14,7 @@ export default class GlimmerTemplatePrecompiler extends Filter {
   processString(content, relativePath) {
     let specifier = getTemplateSpecifier(this.rootName, removeManagerIdFromPath(relativePath));
     let managerId = getManagerIdFromPath(relativePath);
-    let meta = { specifier, '<template-meta>': true };
+    let meta = { specifier };
 
     if (managerId) {
       meta.managerId = managerId;


### PR DESCRIPTION
- Removes `managerId` from filename, if present, and sticks it in the template meta object
- Eliminates unnecessary `'<template-meta>': true` from template meta