### PR TITLE
Introduces ability to extract pragma tag from the template

### DIFF
--- a/lib/compilers/glimmer/extract-pragma-ast-transform.js
+++ b/lib/compilers/glimmer/extract-pragma-ast-transform.js
@@ -1,0 +1,28 @@
+const PRAGMA_TAG = 'use-component-manager';
+
+// Custom Glimmer AST transform to extract custom component
+// manager id from the template
+class ExtractPragmaPlugin {
+  constructor(options) {
+    this.options = options;
+  }
+
+  transform(ast) {
+    let options = this.options;
+
+    this.syntax.traverse(ast, {
+      MustacheStatement: {
+        enter(node) {
+          if (node.path.type === 'PathExpression' && node.path.original === PRAGMA_TAG) {
+            options.meta.managerId = node.params[0].value;
+            return null;
+          }
+        }
+      }
+    });
+
+    return ast;
+  }
+}
+
+module.exports = ExtractPragmaPlugin;

--- a/lib/compilers/glimmer/index.js
+++ b/lib/compilers/glimmer/index.js
@@ -1,6 +1,11 @@
 const path = require('path');
 const Filter = require('broccoli-persistent-filter');
 const { precompile } = require('@glimmer/compiler');
+const ExtractPragmaPlugin = require('./extract-pragma-ast-transform');
+
+function isFeatureFlagEnabled(features, flagName) {
+  return features && !!features[flagName];
+}
 
 export default class GlimmerTemplatePrecompiler extends Filter {
   constructor(inputNode, options) {
@@ -9,14 +14,32 @@ export default class GlimmerTemplatePrecompiler extends Filter {
     this.extensions = ['hbs'];
     this.targetExtension = 'ts';
     this.rootName = options.rootName;
+    this.glimmerEnv = options.GlimmerENV || {};
+    this.plugins = options.plugins || {};
+    this.plugins.ast = this.plugins.ast || [];
+
+    if (isFeatureFlagEnabled(this.glimmerEnv.FEATURES, 'glimmer-custom-component-manager')) {
+      this.registerPlugin(ExtractPragmaPlugin);
+    }
+  }
+
+  registerPlugin(plugin) {
+    this.plugins.ast.push(plugin);
   }
 
   processString(content, relativePath) {
     let specifier = getTemplateSpecifier(this.rootName, relativePath);
-    return `export default ${this.precompile(content, { meta: { specifier, '<template-meta>': true } })};`;
+    let meta = { specifier, managerId: undefined };
+
+    let precompiledContent = this.precompile(content, { meta })
+
+    return `export default ${precompiledContent};`;
   }
 
-  precompile(content, options) {
+  precompile(content, _options) {
+    let plugins = this.plugins;
+    let options = Object.assign({}, _options, { plugins });
+
     return precompile(content, options);
   }
 }


### PR DESCRIPTION
Current pragma tag proposal is `{{use-component-manager "<manager-id>"}}`. Before compiling the template "<manager-id>" part would be extracted and set on template's metadata.

this PR depends on https://github.com/glimmerjs/glimmer-application-pipeline/pull/98 as we want to properly guard this extraction via a feature flag `glimmer-custom-component-manager`.
